### PR TITLE
Fix 修复master分支构建docker镜像失败问题，并去除多余docker标签

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,7 +45,6 @@ jobs:
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:debian-${{ github.ref_name }}
-            ${{ env.IMAGE }}:${{ steps.get_version.outputs.version }}
           build-args: |
             GIT_Branch=${{ github.ref_name }}
       - name: Build Debian Image
@@ -58,7 +57,8 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE }}:debian-${{ github.ref_name }}
-            ${{ env.IMAGE }}:${{ steps.get_version.outputs.version }}
+          build-args: |
+            GIT_Branch=${{ github.ref_name }}
       - name: Build Alpine Image
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
master分支缺少`build-args`参数传递
```
git clone -b $GIT_Branch --single-branch --depth=1 https://github.com/AirportR/FullTclash.git
```
and
https://github.com/AirportR/FullTclash/pull/158#issuecomment-1929155600