### PR TITLE
Update Python version requirement to 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ apt install -y git && git clone https://github.com/AirportR/FullTclash.git && cd
 此方法在中国大陆可能需要代理加速，请自行解决。
 ### 环境准备
 
-- Python 3.9 以上  
+- Python 3.10 以上  
 - 以及各种相关包依赖  
 
 您可以用以下命令，在当前项目目录下运行以快速安装环境：


### PR DESCRIPTION
Operator '|' needs python version 3.10 https://github.com/AirportR/FullTclash/blob/d9eb6062d458f72e8a61e83d9c4a24da98c00b8f/utils/cleaner.py#L1837

[PEP 604 – Allow writing union types as X | Y | peps.python.org](https://peps.python.org/pep-0604/)