### PR TITLE
fix 修复容器更新同步代码后没有执行权限的问题

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,8 @@ ENV startup=1124
 ENV speednodes=300
 ENV speedthread=4
 ENV nospeed=true
+ENV SHELL=/bin/bash
+ENV LANG C.UTF-8
 
 WORKDIR /app
 
@@ -35,6 +37,7 @@ RUN apt-get update && \
     /usr/bin/crontab /etc/cron.d/crontab && \
     chmod +x /app/docker/update.sh && \
     chmod +x /app/docker/docker-entrypoint.sh && \
+    usermod -s /bin/bash root && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=compile-image /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
@@ -42,4 +45,4 @@ COPY --from=compile-image /opt/venv /opt/venv
 
 ENV PATH="/opt/venv/bin:$PATH"
 
-ENTRYPOINT ["/app/docker/docker-entrypoint.sh"]
+ENTRYPOINT ["bash", "/app/docker/docker-entrypoint.sh"]

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -15,6 +15,8 @@ ENV startup=1124
 ENV speednodes=300
 ENV speedthread=4
 ENV nospeed=true
+ENV SHELL=/bin/bash
+ENV LANG C.UTF-8
 
 WORKDIR /app
 
@@ -31,6 +33,7 @@ RUN apk add --no-cache \
     chmod +x /app/docker/fulltcore.sh && \
     bash /app/docker/fulltcore.sh && \
     chmod +x /app/docker/update.sh && \
+    usermod -s /bin/bash root && \
     chmod +x /app/docker/docker-entrypoint.sh
 
 COPY --from=compile-image /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
@@ -38,4 +41,4 @@ COPY --from=compile-image /opt/venv /opt/venv
 
 ENV PATH="/opt/venv/bin:$PATH"
 
-ENTRYPOINT ["/app/docker/docker-entrypoint.sh"]
+ENTRYPOINT ["bash", "/app/docker/docker-entrypoint.sh"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -32,6 +32,17 @@ fi
 
 fi
 
+if [ ! -z "${git_proxy}" ]; then
+mkdir /root/.ssh
+cat > /root/.ssh/config <<EOF
+Host github.com
+    Hostname ssh.github.com
+    Port 443
+    User git
+ProxyCommand connect -S ${git_proxy} %h %p
+EOF
+fi
+
 supervisord -c /etc/supervisord.conf
 
 if [[ -f "/etc/debian_version" ]]; then

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -35,10 +35,8 @@ fi
 if [ ! -z "${git_proxy}" ]; then
 mkdir /root/.ssh
 cat > /root/.ssh/config <<EOF
-Host github.com
-    Hostname ssh.github.com
-    Port 443
-    User git
+Host github.com 
+User git
 ProxyCommand connect -S ${git_proxy} %h %p
 EOF
 fi

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -26,6 +26,7 @@ update() {
     git --git-dir='/app/.git' --work-tree='/app' reset --hard origin/$git_branch
     git --git-dir='/app/.git' --work-tree='/app' pull
     git_version=$(git --git-dir='/app/.git' --work-tree='/app' rev-parse HEAD)
+    chmod -R 755 /app
 }
 
 if [[ $last_version ==  "$git_version" ]]; then


### PR DESCRIPTION
并增加git_proxy环境变量，让部分连接不上GitHub的机器方便一键设置git代理，让git pull更方便.
```
docker run -itd \
   --name=fulltclash \
   --network=host \
   --restart=always \
   -e git_proxy=127.0.0.1:7890 \
   -v /etc/fulltclash/config.yaml:/app/resources/config.yaml \
   airportr/fulltclash:latest
```